### PR TITLE
Reworked exception handling

### DIFF
--- a/pinotdb/exceptions.py
+++ b/pinotdb/exceptions.py
@@ -10,6 +10,18 @@ class InterfaceError(Error):
     pass
 
 
+class NotFoundError(Error):
+    pass
+
+
+class ServerError(Error):
+    pass
+
+
+class ServiceUnavailableError(Error):
+    pass
+
+
 class DatabaseError(Error):
     pass
 
@@ -35,4 +47,12 @@ class DataError(DatabaseError):
 
 
 class NotSupportedError(DatabaseError):
+    pass
+
+
+class QueryTimeoutError(DatabaseError):
+    pass
+
+
+class MalformedQueryResponseError(DatabaseError):
     pass

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -390,7 +390,7 @@ class CursorTest(TestCase):
     def test_checks_sufficient_responded_min1_queried_min1_responded(self):
         cursor = db.Cursor(host='localhost', session=httpx.Client())
 
-        with self.assertRaises(exceptions.DatabaseError):
+        with self.assertRaises(exceptions.QueryTimeoutError):
             cursor.check_sufficient_responded('foo', -1, -1)
 
     def test_checks_sufficient_responded_3_queried_3_responded(self):


### PR DESCRIPTION
The pinot-dbapi connector usually throws very generic errors/exceptions (mostly DatabaseError exceptions) in case something goes wrong while executing a request against Pinot. This makes it quite difficult to distinguish the errors/exceptions within the application that is using the pinot-dbapi connector as a dependency.

In order to improve this, a few changes were made to the error handling code of the pinot-dbapi connector. These changes aim at distinguishing between different errors and throwing different exceptions based off of that. This will make it easier to act upon different errors in a proper way within the applications which are actually using the connector as a dependency.